### PR TITLE
support data.type

### DIFF
--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -745,7 +745,7 @@ class Crossword extends Component {
     return (
       <div
         className={`crossword__container crossword__container--${
-          this.props.data.crosswordType
+          this.props.data.crosswordType || this.props.data.type
         } crossword__container--react`}
         data-link-name="Crosswords"
       >


### PR DESCRIPTION
Hiya! This is Laura from @guardian – First of all ty for extracting the crosswords, this package is proving invaluable in a new digital project we are working on ^o^

Second, at some point, we seem to have changed our API and we now return `data.type` instead of`data.crosswordType`. This is breaking the rendering in our implementation!

This PR fixes our problem and is backwards compatible but I'm not sure if this is something you wanna incorporate in your lib (as it's not guardian specific). If you don't want to merge this could you please let me know so we can fork it? 

if you are happy to work together there's more stuff I'd love to contribute such as theming (purple doesn't really fit our use case haha) so happy to start a conversation!

Best