### PR TITLE
Am revert date solutions available

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+.DS_Store
+log
+logs
+tmp
+RUNNING_PID
+node_modules
+.eslintcache
+*-spec-run
+yarn-error.log

--- a/examples/exampleCrossword.js
+++ b/examples/exampleCrossword.js
@@ -8,6 +8,7 @@ ReactDOM.render(<Crossword data={
       number: 1,
       name: 'Simple Crossword 1',
       date: 1542326400000,
+      instructions: "Numbers in the wordplay of the clues all have something in common and require translation",
       entries: [
         {
           id: '1-across',

--- a/package.json
+++ b/package.json
@@ -1,94 +1,94 @@
 {
-  "name": "react-crossword",
-  "version": "0.1.7",
-  "author": "Chris Zetter",
-  "private": false,
-  "dependencies": {
-    "bean": "~1.0.14",
-    "bonzo": "~2.0.0",
-    "fastdom": "0.8.5",
-    "lodash": "^4.17.11",
-    "qwery": "3.4.2",
-    "svg-inline-loader": "^0.8.0",
-    "wolfy87-eventemitter": "~5.2.4"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
-    "babel-eslint": "^8.2.1",
-    "babel-jest": "^22.2.0",
-    "babel-loader": "^7.1.4",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-env": "^1.6.0",
-    "babel-preset-react": "^6.24.1",
-    "babel-register": "^6.26.0",
-    "chance": "1.0.11",
-    "css-loader": "0.28.7",
-    "eslint": "^5.9.0",
-    "eslint-config-airbnb": "^17.1.0",
-    "eslint-import-resolver-webpack": "^0.10.1",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-jsx-a11y": "^6.1.1",
-    "eslint-plugin-react": "^7.11.0",
-    "jest": "^23.6.0",
-    "jest-environment-jsdom": "^23.4.0",
-    "jest-environment-jsdom-global": "^1.1.0",
-    "node-sass": "^4.10.0",
-    "prettier": "1.13.4",
-    "react": ">=16.4.1",
-    "react-dom": ">=16.4.1",
-    "sass-lint": "~1.10.2",
-    "sass-loader": "^7.1.0",
-    "sass-mq": "~3.3.2",
-    "style-loader": "^0.23.1",
-    "svg-inline-loader": "^0.8.0",
-    "uglify-js": "^2.7.4",
-    "uglifyjs-webpack-plugin": "^1.2.5",
-    "webpack": "^4.1.1",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.10",
-    "webpack-merge": "^4.1.0"
-  },
-  "peerDependencies": {
-    "react": ">=16.4.1",
-    "react-dom": ">=16.4.1"
-  },
-  "optionalDependencies": {
-    "fsevents": "^1.1.2"
-  },
-  "jest": {
-    "roots": [
-      "<rootDir>/src/javascripts"
-    ],
-    "moduleDirectories": [
-      "<rootDir>/src/javascripts",
-      "node_modules"
-    ],
-    "moduleNameMapper": {
-      "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.js"
-    },
-    "testEnvironment": "jest-environment-jsdom-global"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/zetter/react-crossword.git"
-  },
-  "homepage": "https://github.com/zetter/react-crossword",
-  "scripts": {
-    "eslint-fix": "eslint --color --fix src/javascripts examples *.js",
-    "eslint": "eslint --color src/javascripts examples *.js",
-    "sass-lint": "sass-lint --max-warnings 0 -v",
-    "test": "yarn eslint && yarn jest && yarn sass-lint",
-    "examples": "yarn run webpack-dev-server --host 0.0.0.0 --config webpack.config.examples.js",
-    "build": "yarn run webpack --config webpack.config.js"
-  },
-  "files": [
-    "lib"
-  ],
-  "main": "lib/index.js"
+	"name": "@guardian/react-crossword",
+	"version": "0.1.7",
+	"author": "The Guardian, Chris Zetter",
+	"private": false,
+	"dependencies": {
+		"bean": "~1.0.14",
+		"bonzo": "~2.0.0",
+		"fastdom": "0.8.5",
+		"lodash": "^4.17.11",
+		"qwery": "3.4.2",
+		"svg-inline-loader": "^0.8.0",
+		"wolfy87-eventemitter": "~5.2.4"
+	},
+	"devDependencies": {
+		"babel-cli": "^6.26.0",
+		"babel-core": "^6.26.0",
+		"babel-eslint": "^8.2.1",
+		"babel-jest": "^22.2.0",
+		"babel-loader": "^7.1.4",
+		"babel-plugin-add-module-exports": "^0.2.1",
+		"babel-plugin-syntax-dynamic-import": "^6.18.0",
+		"babel-plugin-transform-class-properties": "^6.24.1",
+		"babel-plugin-transform-object-rest-spread": "^6.26.0",
+		"babel-plugin-transform-runtime": "^6.23.0",
+		"babel-polyfill": "^6.26.0",
+		"babel-preset-env": "^1.6.0",
+		"babel-preset-react": "^6.24.1",
+		"babel-register": "^6.26.0",
+		"chance": "1.0.11",
+		"css-loader": "0.28.7",
+		"eslint": "^5.9.0",
+		"eslint-config-airbnb": "^17.1.0",
+		"eslint-import-resolver-webpack": "^0.10.1",
+		"eslint-plugin-import": "^2.14.0",
+		"eslint-plugin-jsx-a11y": "^6.1.1",
+		"eslint-plugin-react": "^7.11.0",
+		"jest": "^23.6.0",
+		"jest-environment-jsdom": "^23.4.0",
+		"jest-environment-jsdom-global": "^1.1.0",
+		"node-sass": "^4.10.0",
+		"prettier": "1.13.4",
+		"react": ">=16.4.1",
+		"react-dom": ">=16.4.1",
+		"sass-lint": "~1.10.2",
+		"sass-loader": "^7.1.0",
+		"sass-mq": "~3.3.2",
+		"style-loader": "^0.23.1",
+		"svg-inline-loader": "^0.8.0",
+		"uglify-js": "^2.7.4",
+		"uglifyjs-webpack-plugin": "^1.2.5",
+		"webpack": "^4.1.1",
+		"webpack-cli": "^3.1.2",
+		"webpack-dev-server": "^3.1.10",
+		"webpack-merge": "^4.1.0"
+	},
+	"peerDependencies": {
+		"react": ">=16.4.1",
+		"react-dom": ">=16.4.1"
+	},
+	"optionalDependencies": {
+		"fsevents": "^1.1.2"
+	},
+	"jest": {
+		"roots": [
+			"<rootDir>/src/javascripts"
+		],
+		"moduleDirectories": [
+			"<rootDir>/src/javascripts",
+			"node_modules"
+		],
+		"moduleNameMapper": {
+			"^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.js"
+		},
+		"testEnvironment": "jest-environment-jsdom-global"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/react-crossword.git"
+	},
+	"homepage": "https://github.com/guardian/react-crossword",
+	"scripts": {
+		"eslint-fix": "eslint --color --fix src/javascripts examples *.js",
+		"eslint": "eslint --color src/javascripts examples *.js",
+		"sass-lint": "sass-lint --max-warnings 0 -v",
+		"test": "yarn eslint && yarn jest && yarn sass-lint",
+		"examples": "yarn run webpack-dev-server --host 0.0.0.0 --config webpack.config.examples.js",
+		"build": "yarn run webpack --config webpack.config.js"
+	},
+	"files": [
+		"lib"
+	],
+	"main": "lib/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/react-crossword",
-	"version": "0.2.0",
+	"version": "0.2.2",
 	"author": "The Guardian, Chris Zetter",
 	"private": false,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/react-crossword",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"author": "The Guardian, Chris Zetter",
 	"private": false,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/react-crossword",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"author": "The Guardian, Chris Zetter",
 	"private": false,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/react-crossword",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"author": "The Guardian, Chris Zetter",
 	"private": false,
 	"dependencies": {

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -698,7 +698,12 @@ class Crossword extends Component {
   }
 
   hasSolutions() {
-    return 'solution' in this.props.data.entries[0];
+    const { dateSolutionAvailable } = this.props.data;
+    const timeNow = new Date().getTime();
+    const solutionShouldBeAvailable =
+      !dateSolutionAvailable || dateSolutionAvailable < timeNow;
+    const solutionExists = "solution" in this.props.data.entries[0]
+    return solutionExists && solutionShouldBeAvailable
   }
 
   isHighlighted(x, y) {

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -745,7 +745,7 @@ class Crossword extends Component {
     return (
       <div
         className={`crossword__container crossword__container--${
-          this.props.data.crosswordType
+          this.props.data.crosswordType || this.props.data.type
         } crossword__container--react`}
         data-link-name="Crosswords"
       >

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -41,6 +41,7 @@ class Crossword extends Component {
     super(props);
     const dimensions = this.props.data.dimensions;
 
+    this.instructions = this.props.data.instructions;
     this.columns = dimensions.cols;
     this.rows = dimensions.rows;
     this.clueMap = buildClueMap(this.props.data.entries);
@@ -811,6 +812,14 @@ class Crossword extends Component {
           clueInFocus={focused}
           crossword={this}
         />
+        {this.instructions && this.instructions.length > 0 &&
+          <div className="crossword__instructions">
+            <header className="instructions__title">
+              Special instructions
+         </header>
+            {this.instructions}
+          </div>
+        }
         <Clues
           clues={this.cluesData()}
           focussed={focused}

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -699,12 +699,7 @@ class Crossword extends Component {
   }
 
   hasSolutions() {
-    const { dateSolutionAvailable } = this.props.data;
-    const timeNow = new Date().getTime();
-    const solutionShouldBeAvailable =
-      !dateSolutionAvailable || dateSolutionAvailable < timeNow;
-    const solutionExists = "solution" in this.props.data.entries[0]
-    return solutionExists && solutionShouldBeAvailable
+    return 'solution' in this.props.data.entries[0];
   }
 
   isHighlighted(x, y) {

--- a/src/stylesheets/crosswords/_clues.scss
+++ b/src/stylesheets/crosswords/_clues.scss
@@ -1,7 +1,6 @@
 .crossword__instructions {
     font-family: $f-sans-serif-text;
-    font-size: 15px;
-    line-height: 18px;
+    @include fs-textSans(5);
     width: 100%;
     clear: both;
 

--- a/src/stylesheets/crosswords/_clues.scss
+++ b/src/stylesheets/crosswords/_clues.scss
@@ -1,3 +1,32 @@
+.crossword__instructions {
+    font-family: $f-sans-serif-text;
+    font-size: 13px;
+    line-height: 18px;
+    width: 100%;
+    clear: both;
+
+    .instructions__title { 
+        font-weight: bold;
+    }
+
+    @include mq(tablet) {
+        clear: none;
+        padding-left: $gs-gutter;
+        box-sizing: border-box;
+
+        noscript & {
+            width: 85%;
+        }
+    }
+
+    @include mq(leftCol) {
+        display: table;
+        table-layout: fixed;
+        height: auto;
+        background: none;
+    }
+}
+
 .crossword__clues-header {
     @include fs-header(1);
     border-bottom: 1px dotted $brightness-86;

--- a/src/stylesheets/crosswords/_clues.scss
+++ b/src/stylesheets/crosswords/_clues.scss
@@ -1,6 +1,6 @@
 .crossword__instructions {
     font-family: $f-sans-serif-text;
-    font-size: 13px;
+    font-size: 15px;
     line-height: 18px;
     width: 100%;
     clear: both;


### PR DESCRIPTION
This reverts https://github.com/guardian/react-crossword/pull/2. 
The changes in this PR were merged but didn't fully work, we had not published a new version of the project since before these changes were released and so the issue has only just been found. 
This revert should ensure that the `Check all` and `Reveal all` buttons are shown as expected. 
![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 09 18 17](https://user-images.githubusercontent.com/53755195/87334011-ea1e1500-c535-11ea-8ff7-af40c6dfadd4.png)
